### PR TITLE
A call to ceil() in /usr/share/dvswitch/include/functions.php fails ...

### DIFF
--- a/var/www/html/include/functions.php
+++ b/var/www/html/include/functions.php
@@ -632,7 +632,7 @@ function getActualMode($metaLastHeard, $mmdvmconfigs) {
     $hangtime = "0";
     $timestamp->add(new DateInterval('PT' . $hangtime . 'S'));
     
-    if ($listElem[6] != null) { //if terminated, hangtime counts after end of transmission
+    if ($listElem[6] != null && is_numeric($listElem[6])) { //if terminated, hangtime counts after end of transmission
 	$timestamp->add(new DateInterval('PT' . ceil($listElem[6]) . 'S'));
     } else { //if not terminated, always return mode
 	return $mode;


### PR DESCRIPTION
…at this line: if ($listElem[6] != null) { //if terminated, hangtime counts after end of transmission

because $listElem[6] is sometimes "DMR Data" rather than a numeric value (possibly representing the hang time), at least when connected to a DMR master. I modified this line to:

if ($listElem[6] != null && is_numeric($listElem[6])) { //if terminated, hangtime counts after end of transmission

... to verify that this field contains a numeric value before setting the timestamp, so that other string values are ignored at this step.